### PR TITLE
misc: Neovim improvements

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -1,4 +1,5 @@
 {
+  "aerial.nvim": { "branch": "master", "commit": "e585934fef8d253dbc5655cff3deb3444e064e6c" },
   "catppuccin": { "branch": "main", "commit": "4fd72a9ab64b393c2c22b168508fd244877fec96" },
   "cmp-buffer": { "branch": "main", "commit": "3022dbc9166796b644a841a02de8dd1cc1d311fa" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "39e2eda76828d88b773cc27a3f61d2ad782c922d" },

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -21,9 +21,9 @@
   "neodev.nvim": { "branch": "main", "commit": "46aa467dca16cf3dfe27098042402066d2ae242d" },
   "nui.nvim": { "branch": "main", "commit": "61574ce6e60c815b0a0c4b5655b8486ba58089a1" },
   "nvim-cmp": { "branch": "main", "commit": "ae644feb7b67bf1ce4260c231d1d4300b19c6f30" },
-  "nvim-lspconfig": { "branch": "master", "commit": "8a3610d29df83d8632f8ee7c3afc779c12725531" },
+  "nvim-lspconfig": { "branch": "master", "commit": "2a6f00ff66e276ab3289be8bb9f844f7ab385848" },
   "nvim-navic": { "branch": "master", "commit": "8649f694d3e76ee10c19255dece6411c29206a54" },
-  "nvim-treesitter": { "branch": "master", "commit": "7499f7379459db3b31c75cf5cec45f785be6e2c7" },
+  "nvim-treesitter": { "branch": "master", "commit": "2eb50352c039009cf046f43241b649b162ee5148" },
   "nvim-treesitter-context": { "branch": "master", "commit": "0f3332788e0bd37716fbd25f39120dcfd557c90f" },
   "nvim-ts-context-commentstring": { "branch": "main", "commit": "375c2d86cee6674afd75b4f727ce3a80065552f7" },
   "nvim-web-devicons": { "branch": "master", "commit": "3722e3d1fb5fe1896a104eb489e8f8651260b520" },
@@ -38,6 +38,6 @@
   "vim-rails": { "branch": "master", "commit": "2fba7907f585819a8653f0bc7dd7f437a822d9c6" },
   "vim-rhubarb": { "branch": "master", "commit": "ee69335de176d9325267b0fd2597a22901d927b1" },
   "vim-ruby": { "branch": "master", "commit": "f06f069ce67bdda6f2cd408f8859cdf031e5b6b4" },
-  "vim-test": { "branch": "master", "commit": "ffbcfc4fa3ac765af2e353e7c3aac7d803592695" },
+  "vim-test": { "branch": "master", "commit": "2c9cef3f7605fc1b272b23765c5872607c1b6183" },
   "vimux": { "branch": "master", "commit": "b110cd95062f5d83a4cb58b807783d783e1fbcd8" }
 }

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -283,8 +283,6 @@ require("lazy").setup({
     keys = {
       { "<Leader>OF", "<cmd>Other<CR>" },
     },
-    config = function()
-    end,
   },
 
   -- Language plugins

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -51,12 +51,24 @@ require("lazy").setup({
   { "lewis6991/gitsigns.nvim",   event = Util.LazyFileEvents, opts = {} }, -- show line diffs inline
   {
     'nvim-lualine/lualine.nvim',
-    dependencies = { 'nvim-tree/nvim-web-devicons' },
-    opts = {
-      options = {
-        theme = "catppuccin",
-      },
+    dependencies = {
+      'nvim-tree/nvim-web-devicons',
+      { 'stevearc/aerial.nvim', opts = { filter_kind = false } },
     },
+    opts = function()
+      local base_config = require("lualine").get_config()
+
+      local conf = vim.tbl_deep_extend("force", base_config, {
+        options = {
+          theme = "catppuccin",
+        },
+        winbar = {
+          lualine_c = { "aerial" },
+        },
+      })
+
+      return conf
+    end,
   },
   {
     "nvim-neo-tree/neo-tree.nvim",

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -131,16 +131,6 @@ require("lazy").setup({
     end,
   },
   {
-    "j-hui/fidget.nvim",
-    opts = {
-      notification = {
-        window = {
-          normal_hl = "",
-        },
-      },
-    },
-  },
-  {
     "nvim-telescope/telescope.nvim", -- UI to browse through basically anything
     dependencies = {
       "nvim-lua/plenary.nvim",
@@ -324,7 +314,17 @@ require("lazy").setup({
           },
         },
         lazy = true,
-      }
+      },
+      {
+        "j-hui/fidget.nvim",
+        opts = {
+          notification = {
+            window = {
+              winblend = 0, -- transparent background LSP loading
+            },
+          },
+        },
+      },
     },
     config = function(_, _)
       local lspconfig = require "lspconfig"

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -292,6 +292,9 @@ require("lazy").setup({
         "rails",
       },
     },
+    config = function(_, opts)
+      require("other-nvim").setup(opts)
+    end,
     keys = {
       { "<Leader>OF", "<cmd>Other<CR>" },
     },

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -55,20 +55,14 @@ require("lazy").setup({
       'nvim-tree/nvim-web-devicons',
       { 'stevearc/aerial.nvim', opts = { filter_kind = false } },
     },
-    opts = function()
-      local base_config = require("lualine").get_config()
-
-      local conf = vim.tbl_deep_extend("force", base_config, {
-        options = {
-          theme = "catppuccin",
-        },
-        winbar = {
-          lualine_c = { "aerial" },
-        },
-      })
-
-      return conf
-    end,
+    opts = {
+      options = {
+        theme = "catppuccin",
+      },
+      winbar = {
+        lualine_b = { "aerial" },
+      },
+    },
   },
   {
     "nvim-neo-tree/neo-tree.nvim",


### PR DESCRIPTION
1. Makes `fidget.nvim` (which provides the little "LSP loading" window) transparent.
2. Makes `fidget.nvim` a requirement for nvim-lsp.
3. `other.nvim` doesn't auto-execute `.setup(opts)`; invoke it manually.
4. Add Treesitter/LSP breadcrumbs to `lualine`.